### PR TITLE
Update supersonic-updater-windows.ps1

### DIFF
--- a/supersonic-updater-windows.ps1
+++ b/supersonic-updater-windows.ps1
@@ -6,7 +6,7 @@ Write-Output "Supersonic Update Script for Windows`nCreated by Gavin Liddell`nRe
 Write-Output "Checking for update..."
 
 Function Find-Path {
-    $timeoutSeconds = 2
+    $timeoutSeconds = 5
     $pathSearch = {Get-ChildItem -Path C:\ -Filter 'Supersonic.exe' -Exclude '*.pf' -File -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1}
     $j = Start-Job -ScriptBlock $pathSearch
     If (Wait-Job $j -Timeout $timeoutSeconds) {
@@ -41,37 +41,68 @@ Function Pull-Latest {
 
 $latest = Pull-Latest
 
-Function Run-Process {
+Function Check-Path {
+    $checkLoc = Test-Path "$env:ProgramFiles\Supersonic"
+    If ($filePath -ne $null) {Return $filePath}
+    ElseIf ($filePath -eq $null -and $checkLoc -ne $false) {
+        $installPath = "$env:ProgramFiles\Supersonic"
+        Return $installPath
+    } Else {
+        New-Item "$env:ProgramFiles\Supersonic" -ItemType "directory"
+        $installPath = "$env:ProgramFiles\Supersonic"
+        Return $installPath
+    }
+}
+
+$appPath = Check-Path
+
+Function Install-Update {
     $url = "https://github.com/dweymouth/supersonic/releases/latest/download/Supersonic-$latest-windows-x64.zip"
     $location = "$env:temp\Supersonic-$latest-windows-x64.zip"
-    $checkLoc = Test-Path "$env:ProgramFiles\Supersonic"
-    Invoke-WebRequest -Uri $url -OutFile "$location"
-    If ($filePath -eq $null -and $checkLoc -eq $false) {
-        New-Item -Path "$env:ProgramFiles" -Name "Supersonic" -ItemType "directory"
-        $installpath = "$env:ProgramFiles\Supersonic"
-    } Else {$installpath = "$env:ProgramFiles\Supersonic"}
-    Expand-Archive -Path "$location" -DestinationPath "$installPath" -Force
-    Remove-Item -Path "$env:temp\Supersonic-$latest-windows-x64.zip"
+    $testLocation = Test-Path $location
+    If ($testLocation -eq $true) {Expand-Archive -Path "$location" -DestinationPath "$appPath" -Force}
+    Else {
+        Invoke-WebRequest -Uri $url -OutFile "$location"
+        Expand-Archive -Path "$location" -DestinationPath "$appPath" -Force
+    }
+    Return
+}
+
+Function Test-Install {
+    $testInstall = Test-Path $appPath\Supersonic.exe
+    If ($testInstall -eq $true) {Write-Output "Supersonic installed successfully!"}
+    Else {Write-Output "Supersonic failed to install."}
     Return
 }
 
 Function Update-Shortcut {
+    $shortcutPath = "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Supersonic.lnk"
+    $testShortcut = Test-Path "$shortcutPath"
+    If ($testShortcut = $true) {Remove-Item -Path "$shortcutPath"}
     $shell = New-Object -ComObject WScript.Shell
     $shortcut = $shell.CreateShortcut("$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Supersonic.lnk")
-    $shortcut.TargetPath = "$installPath\Supersonic.exe"
+    $shortcut.TargetPath = "$appPath\Supersonic.exe"
     $shortcut.Save()
     Return
 }
 
-If ($env:PROCESSOR_ARCHITECTURE -ne "AMD64") {Write-Error "Unsupported platform detected! This program only supports x64 processors."}
-ElseIf ($local -eq $latest) {Write-Output "You are up-to-date!"}
-ElseIf ($local -ne $null) {Write-Output "Detected version: $local`nLatest version: $latest"}
+If ($env:PROCESSOR_ARCHITECTURE -ne "AMD64") {
+    Write-Error "Unsupported platform detected! This program only supports x64 processors."
+    Return
+} ElseIf ($local -eq $latest) {
+    Write-Output "Detected version: $local`nLatest version: $latest"
+    Write-Output "You are up-to-date!"
+    Update-Shortcut
+}
 ElseIf ($local -eq $null) {
     Write-Output "Supersonic not installed!`nInstalling..."
-    Run-Process
+    Install-Update
     Update-Shortcut
+    Test-Install
 } Else {
+    Write-Output "Detected version: $local`nLatest version: $latest"
     Write-Output "Your Supersonic version is out-of-date!`nInstalling the latest update..."
-    Run-Process
+    Install-Update
     Update-Shortcut
+    Test-Install
 }


### PR DESCRIPTION
- Fixed some capitalization mismatches
- Fixed an if statement that stopped the script arbitrarily
- Added some checks to confirm the script is running properly
- Refactored some functions for easier maintenance
- Change the logic to utilize a local download rather than download the zip file every time the script is run
- Extended the Find-Path timeout for slower drives